### PR TITLE
Update API keys

### DIFF
--- a/apollo/server/models/SocSetting.ts
+++ b/apollo/server/models/SocSetting.ts
@@ -11,10 +11,14 @@ export interface SocSettingAttributes {
   id: number;
   key: string;
   value: string;
+  updatedAt: Date;
 }
 
 /** All the attributes needed to create an instance of the SocSetting model */
-export type SocSettingCreationAttributes = Optional<SocSettingAttributes, "id">;
+export type SocSettingCreationAttributes = Optional<
+  SocSettingAttributes,
+  "id" | "updatedAt"
+>;
 
 /** A class for the SocSetting model */
 export class SocSetting
@@ -55,6 +59,7 @@ export const SocSettingFactory = (sequelize: Sequelize): typeof SocSetting => {
         type: DataTypes.STRING,
         allowNull: false,
       },
+      updatedAt: DataTypes.DATE,
     },
     {
       sequelize,

--- a/apollo/server/models/SocSetting.ts
+++ b/apollo/server/models/SocSetting.ts
@@ -11,14 +11,10 @@ export interface SocSettingAttributes {
   id: number;
   key: string;
   value: string;
-  updatedAt: Date;
 }
 
 /** All the attributes needed to create an instance of the SocSetting model */
-export type SocSettingCreationAttributes = Optional<
-  SocSettingAttributes,
-  "id" | "updatedAt"
->;
+export type SocSettingCreationAttributes = Optional<SocSettingAttributes, "id">;
 
 /** A class for the SocSetting model */
 export class SocSetting
@@ -59,7 +55,6 @@ export const SocSettingFactory = (sequelize: Sequelize): typeof SocSetting => {
         type: DataTypes.STRING,
         allowNull: false,
       },
-      updatedAt: DataTypes.DATE,
     },
     {
       sequelize,

--- a/apollo/server/resolvers/socSetting.ts
+++ b/apollo/server/resolvers/socSetting.ts
@@ -77,14 +77,18 @@ const initClientKeysResolver: ResolverFn<
 > = async (
   _,
   { id, secret },
-  { dataSources }
+  { user, dataSources }
 ): Promise<ClientKeysUpdateResponse> => {
-  /* const hasExecutives = Boolean(
+  const hasExecutives = Boolean(
     await dataSources.executiveAPI.countExecutives()
   );
-  if (hasExecutives) {
-    return { success: false, message: "You have no permission to read this" };
-  } */
+  const isAdmin = Boolean(
+    user && (await dataSources.executiveAPI.findExecutive(user.sid))
+  );
+  if (hasExecutives && !isAdmin) {
+    return { success: false, message: "You have no permission to do this" };
+  }
+
   const idResult = await dataSources.socSettingAPI.updateSocSetting({
     key: NEW_CLIENT_ID_KEY,
     value: id,

--- a/apollo/server/resolvers/socSetting.ts
+++ b/apollo/server/resolvers/socSetting.ts
@@ -5,7 +5,7 @@
 
 import { gql } from "apollo-server";
 import { ResolverFn, Resolvers } from "@/types/resolver";
-import { CLIENT_ID_KEY, CLIENT_SECRET_KEY } from "utils/auth";
+import { NEW_CLIENT_ID_KEY, NEW_CLIENT_SECRET_KEY } from "utils/auth";
 import {
   SocSettingAttributes,
   SocSettingCreationAttributes,
@@ -79,18 +79,18 @@ const initClientKeysResolver: ResolverFn<
   { id, secret },
   { dataSources }
 ): Promise<ClientKeysUpdateResponse> => {
-  const hasExecutives = Boolean(
+  /* const hasExecutives = Boolean(
     await dataSources.executiveAPI.countExecutives()
   );
   if (hasExecutives) {
     return { success: false, message: "You have no permission to read this" };
-  }
+  } */
   const idResult = await dataSources.socSettingAPI.updateSocSetting({
-    key: CLIENT_ID_KEY,
+    key: NEW_CLIENT_ID_KEY,
     value: id,
   });
   const secretResult = await dataSources.socSettingAPI.updateSocSetting({
-    key: CLIENT_SECRET_KEY,
+    key: NEW_CLIENT_SECRET_KEY,
     value: secret,
   });
   if (!idResult || !secretResult) {

--- a/layouts/admin.tsx
+++ b/layouts/admin.tsx
@@ -90,6 +90,11 @@ const Layout: React.FunctionComponent<Props> = ({ children }: Props) => {
                   Settings
                 </Navbar.Item>
               </Link>
+              <Link href="/admin/authentication">
+                <Navbar.Item onClick={() => setActive(false)}>
+                  Authentication
+                </Navbar.Item>
+              </Link>
             </Navbar.Container>
             <Navbar.Container position="end">
               <Link href="/api/logout">

--- a/pages/admin/authentication.tsx
+++ b/pages/admin/authentication.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from "react";
+import { useRouter } from "next/router";
+import { useMutation } from "@apollo/react-hooks";
+import Layout from "layouts/admin";
+import toast from "utils/toast";
+import { getMicrosoftLoginLink } from "utils/microsoftLogin";
+
+import {
+  Button,
+  Form,
+  Section,
+  Container,
+  Heading,
+} from "react-bulma-components";
+import initClientKeysMutation from "apollo/queries/socSetting/initClientKeys.gql";
+
+const { Input, Field, Control, Label } = Form;
+
+const Authentication = (): React.ReactElement => {
+  const router = useRouter();
+  const [
+    initClientKeys,
+    {
+      loading: initClientKeysMutationLoading,
+      error: initClientKeysMutationError,
+    },
+  ] = useMutation(initClientKeysMutation);
+
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const formSubmit = async (e: React.FormEvent<HTMLElement>) => {
+    e.preventDefault();
+    try {
+      const updateSocSettingPayload = await initClientKeys({
+        variables: {
+          id: clientId,
+          secret: clientSecret,
+        },
+      });
+      if (!updateSocSettingPayload.data.initClientKeys.success) {
+        throw new Error(updateSocSettingPayload.data.initClientKeys.message);
+      }
+      const link = getMicrosoftLoginLink({
+        baseUrl: window.location.origin,
+        clientId,
+      });
+      router.push(link);
+    } catch (err) {
+      toast.danger(err.message, {
+        position: toast.POSITION.TOP_LEFT,
+      });
+    }
+  };
+
+  return (
+    <div>
+      <Section>
+        <Container>
+          <Heading>Authentication</Heading>
+          <Heading subtitle renderAs="h2">
+            Change authentication API key
+          </Heading>
+          <form onSubmit={(e) => formSubmit(e)}>
+            <Field>
+              <Label>Client ID</Label>
+              <Control>
+                <Input
+                  value={clientId}
+                  onChange={(
+                    event: React.ChangeEvent<HTMLInputElement>
+                  ): void => setClientId(event.target.value)}
+                />
+              </Control>
+            </Field>
+            <Field>
+              <Label>Client Secret</Label>
+              <Control>
+                <Input
+                  value={clientSecret}
+                  onChange={(
+                    event: React.ChangeEvent<HTMLInputElement>
+                  ): void => setClientSecret(event.target.value)}
+                />
+              </Control>
+            </Field>
+            <Button color="primary" type="submit">
+              Authentication
+            </Button>
+          </form>
+          {initClientKeysMutationLoading && <p>Loading...</p>}
+          {initClientKeysMutationError && <p>Error :( Please try again</p>}
+        </Container>
+      </Section>
+    </div>
+  );
+};
+
+Authentication.Layout = Layout;
+
+export default Authentication;

--- a/pages/admin/authentication.tsx
+++ b/pages/admin/authentication.tsx
@@ -84,7 +84,7 @@ const Authentication = (): React.ReactElement => {
               </Control>
             </Field>
             <Button color="primary" type="submit">
-              Authentication
+              Authenticate
             </Button>
           </form>
           {initClientKeysMutationLoading && <p>Loading...</p>}

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -6,27 +6,64 @@ import {
   issureJwt,
   setJwtHeader,
   getSetting,
+  swapAPIKey,
+  deleteNewAPIKey,
+  NEW_CLIENT_ID_KEY,
+  NEW_CLIENT_SECRET_KEY,
   CLIENT_ID_KEY,
   CLIENT_SECRET_KEY,
 } from "utils/auth";
 import { getClientIp } from "request-ip";
+
+interface AccessTokenProps {
+  accessToken: string;
+  key: string;
+}
 
 /**
  * Get access token from microsoft
  * @async
  * @param {string} baseUrl - The base url of the server
  * @param {string} code - The authorization code
- * @returns {Promise<string | undefined>} The access token
+ * @returns {Promise<AccessTokenProps | undefined>} The access token and respective key used
  */
 const getAccessToken = async (
   baseUrl: string,
   code: string
-): Promise<string | undefined> => {
-  /* TODO put CLIENT_ID and CLIENT_SECRET to database */
+): Promise<AccessTokenProps | undefined> => {
   const TENANT = "link.cuhk.edu.hk";
+  const newClientId = await getSetting(NEW_CLIENT_ID_KEY);
+  const newClientSecret = await getSetting(NEW_CLIENT_SECRET_KEY);
   const clientId = await getSetting(CLIENT_ID_KEY);
   const clientSecret = await getSetting(CLIENT_SECRET_KEY);
   const redirectUrl = `${baseUrl}/api/login`;
+
+  const link = `https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token`;
+  const body = {
+    client_id: "",
+    scope: "user.read",
+    code,
+    redirect_uri: redirectUrl,
+    grant_type: "authorization_code",
+    client_secret: "",
+  };
+
+  // decision on which set of API keys to use
+  if (newClientId && newClientSecret) {
+    body.client_id = newClientId;
+    body.client_secret = newClientSecret;
+    try {
+      const tokenResponse = await axios.post(link, qs.stringify(body));
+      return {
+        accessToken: tokenResponse.data.access_token,
+        key: NEW_CLIENT_ID_KEY,
+      };
+    } catch (err) {
+      console.log(err);
+    }
+  } else {
+    console.log("No vaild new API key pairs found");
+  }
 
   if (!clientId) {
     throw new Error("Cannot find client id");
@@ -35,19 +72,12 @@ const getAccessToken = async (
     throw new Error("Cannot find client secret");
   }
 
-  const link = `https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token`;
-  const body = qs.stringify({
-    client_id: clientId,
-    scope: "user.read",
-    code,
-    redirect_uri: redirectUrl,
-    grant_type: "authorization_code",
-    client_secret: clientSecret,
-  });
+  body.client_id = clientId;
+  body.client_secret = clientSecret;
 
   try {
-    const tokenResponse = await axios.post(link, body);
-    return tokenResponse.data.access_token;
+    const tokenResponse = await axios.post(link, qs.stringify(body));
+    return { accessToken: tokenResponse.data.access_token, key: CLIENT_ID_KEY };
   } catch {
     return undefined;
   }
@@ -113,7 +143,13 @@ export default async (
     return;
   }
 
-  const user = await getUser(req, accessToken);
+  if (accessToken.key === NEW_CLIENT_ID_KEY) {
+    swapAPIKey();
+  } else {
+    deleteNewAPIKey();
+  }
+
+  const user = await getUser(req, accessToken.accessToken);
 
   if (!user) {
     res.status(401).end("Cannot access user data.");

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -4,6 +4,7 @@ import {
   getUserAndRefreshToken,
   getSetting,
   countExecutives,
+  NEW_CLIENT_ID_KEY,
   CLIENT_ID_KEY,
 } from "utils/auth";
 import { getMicrosoftLoginLink } from "utils/microsoftLogin";
@@ -24,12 +25,21 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const { host = "" } = ctx.req.headers;
   const protocol = /^localhost/g.test(host) ? "http" : "https";
   const baseUrl = `${protocol}://${ctx.req.headers.host}`;
+  const newClientId = await getSetting(NEW_CLIENT_ID_KEY);
   const clientId = await getSetting(CLIENT_ID_KEY);
   const executives = await countExecutives();
   if (!executives) {
     ctx.res.statusCode = 307;
     ctx.res.setHeader("Location", "/initialise");
     return EMPTY_PROPS;
+  }
+  if (newClientId) {
+    return {
+      props: {
+        baseUrl,
+        clientId: newClientId,
+      },
+    };
   }
   if (!clientId) {
     ctx.res.statusCode = 500;

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -34,11 +34,10 @@ export const getSetting = async (key: string): Promise<string | undefined> => {
  */
 export const getSettingWithTime = async (
   key: string
-): Promise<{ value: string; updatedAt: Date } | undefined> => {
+): Promise<{ value: string | undefined; updatedAt: Date | undefined }> => {
   const entry = await socSettingStore.findOne({
     where: { key },
   });
-  if (!entry || !entry.getDataValue("value")) return undefined;
   return {
     value: entry?.getDataValue("value"),
     updatedAt: entry?.getDataValue("updatedAt"),

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -10,6 +10,8 @@ import { getClientIp } from "request-ip";
 export const JWT_SECRET_KEY = "jwt_secret";
 export const CLIENT_ID_KEY = "client_id";
 export const CLIENT_SECRET_KEY = "client_secret";
+export const NEW_CLIENT_ID_KEY = "new_client_id";
+export const NEW_CLIENT_SECRET_KEY = "new_client_secret";
 
 /**
  * Get a specific settings from the database

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -37,10 +37,11 @@ export const getSettingWithTime = async (
 ): Promise<{ value: string | undefined; updatedAt: Date | undefined }> => {
   const entry = await socSettingStore.findOne({
     where: { key },
+    raw: true,
   });
   return {
-    value: entry?.getDataValue("value"),
-    updatedAt: entry?.getDataValue("updatedAt"),
+    value: entry?.value,
+    updatedAt: entry?.updatedAt,
   };
 };
 

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -143,3 +143,33 @@ export const getUser = async (req: IncomingMessage): Promise<User | null> => {
     return null;
   }
 };
+
+/**
+ * Remove new API keys inputted from user
+ * @async
+ */
+export const deleteNewAPIKey = async (): Promise<void> => {
+  await socSettingStore.destroy({ where: { key: NEW_CLIENT_ID_KEY } });
+  await socSettingStore.destroy({ where: { key: NEW_CLIENT_SECRET_KEY } });
+};
+
+/**
+ * Update API keys with new API keys inputted from user
+ * @async
+ */
+export const swapAPIKey = async (): Promise<void> => {
+  const newID = await socSettingStore.findOne({
+    where: { key: NEW_CLIENT_ID_KEY },
+  });
+  const newIDKey = newID?.getDataValue("value");
+  const newSecret = await socSettingStore.findOne({
+    where: { key: NEW_CLIENT_SECRET_KEY },
+  });
+  const newSecretKey = newSecret?.getDataValue("value");
+  if (!newIDKey || !newSecretKey) {
+    throw new Error("Invalid Key");
+  }
+  await socSettingStore.upsert({ key: CLIENT_ID_KEY, value: newIDKey });
+  await socSettingStore.upsert({ key: CLIENT_SECRET_KEY, value: newSecretKey });
+  deleteNewAPIKey();
+};


### PR DESCRIPTION
Fix #19 

1. A new admin panel is added for changing API keys.
2. `initClientKeys` mutation is now saving to `new_client_id` and `new_client_secret` instead
3. `initClientKeys` mutation can be executed by admins after system initialisation
4. Key validity is checked by redirecting users to Microsoft Login instantly. If new keys are working and users can be logged on, new keys are saved into `client_id` and `client_secret` replacing existing values.